### PR TITLE
Fix index page links

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,9 +11,9 @@ This is the `Trussels' Guide`, written by Trussels for Trussels. We share it her
 
 We have two guides published right now:
 
-* The [`Trussels' Guide to Truss`](trussels), which is about Truss, the organization.
-* The [`Truss Distributed Playbook`](distributed), which is about distributed work.
-* The [`How to Open Source like a Trussel`](opensource), which is about how we do OSS software.
+* The [`Trussels' Guide to Truss`]({{ '/docs/trussels' | relative_url }}), which is about Truss, the organization.
+* The [`Truss Distributed Playbook`]({{ '/docs/distributed' | relative_url }}), which is about distributed work.
+* The [`How to Open Source like a Trussel`]({{ '/docs/opensource/opensource' | relative_url }}), which is about how we do OSS software.
 
 These are licensed [CC-BY 4.0 International]({{ '/docs/opensource/LICENSE-CC-BY-4.0' | relative_url }}).
 


### PR DESCRIPTION
DOH. Index page links were broken due to the move to docs dir. Fix it real quick.