### PR TITLE
separateMultipleMajor to false

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,6 @@
         "every weekday",
         "after 9am and before 5pm"
     ],
-    "separateMultipleMajor": true,
     "timezone": "America/Los_Angeles",
     "packageRules": [
         {

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,8 @@
     "extends": [
         "config:base"
     ],
+    "prConcurrentLimit": 0,
+    "prHourlyLimit": 0,
     "schedule": [
         "every weekday",
         "after 9am and before 5pm"


### PR DESCRIPTION
I must have misunderstood what this does, because with 'true', we got separate PRs for every intermediate version of github-pages. That was a lot of unnecessary PRs.

Also, [61fd889](https://github.com/trussworks/trussels-guide/pull/101/commits/61fd889026e2dbdcc8d013a45af1ba67fa390747) disables rate-limiting.